### PR TITLE
quality of life improvements

### DIFF
--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -28,14 +28,18 @@ class MigrationManager(object):
                                            self.config.mongo_url)
         files = os.listdir(self.config.mongo_migrations_path)
         for file in files:
-            result = re.match('^(\d+)[_a-z]*\.py$', file)
+            result = re.match('^(\d+).*\.py$', file)
             if result:
                 self.migrations[result.group(1)] = file[:-3]
 
         database_migrations = self._get_migration_names()
+        #NOTE this is the list of datetimes already run
         self.database_migration_names = [migration['migration_datetime'] for migration in database_migrations]
         if set(self.database_migration_names) - set(self.migrations.keys()):
-            print("migrations doesn't match")
+            print("ERROR: migrations do not match")
+            print ("your db has run migrations with the following unexpected datetimes:")
+            for migration_datetime in set(self.database_migration_names) - set(self.migrations.keys()):
+                print('\t'+migration_datetime)
             sys.exit(1)
         if self.database_migration_names:
             print("Found previous migrations, last migration is version: %s" % self.database_migration_names[0])
@@ -50,7 +54,7 @@ class MigrationManager(object):
 
     def _do_migrate(self):
         for migration_datetime in sorted(self.migrations.keys()):
-            if not self.database_migration_names or migration_datetime > self.database_migration_names[0]:
+            if migration_datetime not in self.database_migration_names:
                 print("Trying to upgrade version: %s" % self.migrations[migration_datetime])
                 try:
                     module = __import__(self.migrations[migration_datetime])

--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -33,7 +33,6 @@ class MigrationManager(object):
                 self.migrations[result.group(1)] = file[:-3]
 
         database_migrations = self._get_migration_names()
-        #NOTE this is the list of datetimes already run
         self.database_migration_names = [migration['migration_datetime'] for migration in database_migrations]
         if set(self.database_migration_names) - set(self.migrations.keys()):
             print("ERROR: migrations do not match")


### PR DESCRIPTION
This PR makes three changes to mongodb_migrations:

makes migration order not matter. so if a migration with an earlier datetime is merged after a migration with a later datetime, the earlier one will not be skipped.

currently, migrations are skipped if they contain characters like - or + in the name. This fixes that so every file that starts with a number and ends with .py is run

provides a more informative error message when migrations don't sync up, listing the unexpected migrations